### PR TITLE
Arize dev/workload identity support

### DIFF
--- a/broker/fragment/store_gcs.go
+++ b/broker/fragment/store_gcs.go
@@ -186,8 +186,7 @@ func (s *gcsBackend) gcsClient(ep *url.URL) (cfg GSStoreConfig, client *storage.
 
 		s.client = client
 
-		// TODO(djd): do i need to form a signed URL options or change this file to work without one?
-		// Looking at SignGet() it seems like I do need to form signed URL options. Just give it a try.
+		// Note: SignGet() also works with empty signedURLOptions.
 
 		log.WithFields(log.Fields{
 			"ProjectID": creds.ProjectID,

--- a/broker/fragment/store_gcs.go
+++ b/broker/fragment/store_gcs.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	pb "go.gazette.dev/core/broker/protocol"
 	"golang.org/x/oauth2/google"
+	"golang.org/x/oauth2/jwt"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -132,6 +133,8 @@ func (s *gcsBackend) Remove(ctx context.Context, fragment pb.Fragment) error {
 }
 
 func (s *gcsBackend) gcsClient(ep *url.URL) (cfg GSStoreConfig, client *storage.Client, opts storage.SignedURLOptions, err error) {
+	var conf *jwt.Config
+
 	if err = parseStoreArgs(ep, &cfg); err != nil {
 		return
 	}
@@ -153,7 +156,7 @@ func (s *gcsBackend) gcsClient(ep *url.URL) (cfg GSStoreConfig, client *storage.
 	if err != nil {
 		return
 	} else if creds.JSON != nil {
-		conf, err := google.JWTConfigFromJSON(creds.JSON, storage.ScopeFullControl)
+		conf, err = google.JWTConfigFromJSON(creds.JSON, storage.ScopeFullControl)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Do not error out if when we find our credentials they did not come from a json file containing a gcp service account. For workload identity FindDefaultCredentials() will not fill in the creds.JSON field but rather will attach a creds.TokenSource directly that can be used by storage.NewClient().

We leave s.signedURLOptions empty which does not seem to affect the operation of SignGet() function at top of the file.

This was tested to operate on an on-prem test cluster. As store_gcs.go is not used by the arize gazette consumers we did not have to change the arize go.mod file to pick up this change. Only the gazette broker needs a new image.