### PR TITLE
Arize dev/workload identity fix

### DIFF
--- a/broker/fragment/store_gcs.go
+++ b/broker/fragment/store_gcs.go
@@ -44,12 +44,7 @@ func (s *gcsBackend) SignGet(ep *url.URL, fragment pb.Fragment, d time.Duration)
 	opts.Method = "GET"
 	opts.Expires = time.Now().Add(d)
 
-	if opts.GoogleAccessID == "" {
-		// workload identity approach
-		return client.Bucket(cfg.bucket).SignedURL(cfg.rewritePath(cfg.prefix, fragment.ContentPath()), &opts)
-	} else {
-		return storage.SignedURL(cfg.bucket, cfg.rewritePath(cfg.prefix, fragment.ContentPath()), &opts)
-	}
+	return client.Bucket(cfg.bucket).SignedURL(cfg.rewritePath(cfg.prefix, fragment.ContentPath()), &opts)
 }
 
 func (s *gcsBackend) Exists(ctx context.Context, ep *url.URL, fragment pb.Fragment) (exists bool, err error) {
@@ -189,7 +184,8 @@ func (s *gcsBackend) gcsClient(ep *url.URL) (cfg GSStoreConfig, client *storage.
 			return
 		}
 
-		// workload identity approach which aligns with a path in SignGet() method
+		// workload identity approach which SignGet() method accepts if you have
+		// "iam.serviceAccounts.signBlob" permissions against your service account.
 		opts = storage.SignedURLOptions{}
 		s.client, s.signedURLOptions = client, opts
 

--- a/broker/fragment/store_gcs.go
+++ b/broker/fragment/store_gcs.go
@@ -45,6 +45,11 @@ func (s *gcsBackend) SignGet(ep *url.URL, fragment pb.Fragment, d time.Duration)
 	opts.Expires = time.Now().Add(d)
 
 	if opts.GoogleAccessID == "" {
+		// workload identity approach
+		log.WithFields(log.Fields{
+			"bucket": cfg.bucket,
+			"prefix": cfg.prefix,
+		}).Info("SignGet with workload identity approach")
 		return client.Bucket(cfg.bucket).SignedURL(cfg.prefix, &opts)
 	} else {
 		return storage.SignedURL(cfg.bucket, cfg.rewritePath(cfg.prefix, fragment.ContentPath()), &opts)
@@ -188,6 +193,7 @@ func (s *gcsBackend) gcsClient(ep *url.URL) (cfg GSStoreConfig, client *storage.
 			return
 		}
 
+		// workload identity approach which aligns with a path in SignGet() method
 		opts = storage.SignedURLOptions{}
 		s.client, s.signedURLOptions = client, opts
 

--- a/broker/fragment/store_gcs.go
+++ b/broker/fragment/store_gcs.go
@@ -46,10 +46,6 @@ func (s *gcsBackend) SignGet(ep *url.URL, fragment pb.Fragment, d time.Duration)
 
 	if opts.GoogleAccessID == "" {
 		// workload identity approach
-		log.WithFields(log.Fields{
-			"bucket": cfg.bucket,
-			"prefix": cfg.prefix,
-		}).Info("SignGet with workload identity approach")
 		return client.Bucket(cfg.bucket).SignedURL(cfg.prefix, &opts)
 	} else {
 		return storage.SignedURL(cfg.bucket, cfg.rewritePath(cfg.prefix, fragment.ContentPath()), &opts)

--- a/broker/fragment/store_gcs.go
+++ b/broker/fragment/store_gcs.go
@@ -46,7 +46,7 @@ func (s *gcsBackend) SignGet(ep *url.URL, fragment pb.Fragment, d time.Duration)
 
 	if opts.GoogleAccessID == "" {
 		// workload identity approach
-		return client.Bucket(cfg.bucket).SignedURL(cfg.prefix, &opts)
+		return client.Bucket(cfg.bucket).SignedURL(cfg.rewritePath(cfg.prefix, fragment.ContentPath()), &opts)
 	} else {
 		return storage.SignedURL(cfg.bucket, cfg.rewritePath(cfg.prefix, fragment.ContentPath()), &opts)
 	}

--- a/broker/fragment/store_gcs.go
+++ b/broker/fragment/store_gcs.go
@@ -44,7 +44,7 @@ func (s *gcsBackend) SignGet(ep *url.URL, fragment pb.Fragment, d time.Duration)
 	opts.Method = "GET"
 	opts.Expires = time.Now().Add(d)
 
-	if opt.GoogleAccessID == "" {
+	if opts.GoogleAccessID == "" {
 		return client.Bucket(cfg.bucket).SignedURL(cfg.prefix, &opts)
 	} else {
 		return storage.SignedURL(cfg.bucket, cfg.rewritePath(cfg.prefix, fragment.ContentPath()), &opts)


### PR DESCRIPTION
Changes to create SignedURL when starting from workload identity credentials. Inspired by https://github.com/salrashid123/gcs_signedurl which was mentioned in https://github.com/salrashid123/workload_signedurl?tab=readme-ov-file#signed-url-using-gke-workload-federation.

Also https://pkg.go.dev/cloud.google.com/go/storage#hdr-Credential_requirements_for_signing.