### PR TITLE
move to golang 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.gazette.dev/core
 
-go 1.25
+go 1.25.7
 
 require (
 	cloud.google.com/go/storage v1.57.0


### PR DESCRIPTION
CVEs in the stdlib are fixed in golang 1.25.7