### PR TITLE
fix: make extra checks when not using a recovery log

### DIFF
--- a/consumer/recovery.go
+++ b/consumer/recovery.go
@@ -275,10 +275,21 @@ func completeRecovery(s *shard) (_ pc.Checkpoint, err error) {
 		// completing InjectHandoff will cause appends of this Recorder to fail.
 		s.recovery.recorder = recoverylog.NewRecorder(
 			s.recovery.log, recovered.FSM, author, recovered.Dir, s.ajc)
+	} else {
+		// Without a recovery log there is no player to wait on, but we must
+		// still check for context cancellation before creating a store.
+		// This prevents a cancelled shard (e.g. from a delete-then-create
+		// race in updateLocalShards) from proceeding into NewStore.
+		select {
+		case <-s.ctx.Done():
+			err = s.ctx.Err()
+			return
+		default:
+		}
 	}
 
 	if s.store, err = s.svc.App.NewStore(s, s.recovery.recorder); err != nil {
-		if s.store == nil {
+		if s.store == nil && s.recovery.recorder != nil {
 			// s.store is nil, ergo its Destroy() will not be invoked by
 			// waitAndTearDown(), and we are responsible for best-effort
 			// cleanup of the playback directory now.


### PR DESCRIPTION
Summary

  Fix 1: Context cancellation check for shards without recovery logs

  File: consumer/recovery.go — completeRecovery()

  When a shard has no recovery log, completeRecovery previously skipped directly to NewStore() without checking if the shard's context had been
  cancelled. This creates a race window in the delete-then-create path (updateLocalShards at resolver.go:310): the old shard's servePrimary goroutine
  can still be running through completeRecovery after the shard is cancelled, allowing it to call NewStore on a stale shard and trigger a nil pointer
  dereference on shard.Spec().

  Added an else branch to the existing if s.recovery.log != "" check that performs a non-blocking context cancellation check, mirroring the protection
  that already exists for shards with recovery logs (via the select on s.recovery.player.Done() / s.ctx.Done()).

  Fix 2: Nil guard on recorder in NewStore error path

  File: consumer/recovery.go — completeRecovery()

  When NewStore returns an error and s.store is nil, the cleanup path called s.recovery.recorder.Dir() unconditionally. Since recorder is nil for
  shards without a recovery log, this would panic. Added a nil check on s.recovery.recorder before attempting the RemoveAll cleanup.